### PR TITLE
[BUGFIX] Show error messages when debugging is enabled

### DIFF
--- a/eid/class.tx_schedulerhttp_eid.php
+++ b/eid/class.tx_schedulerhttp_eid.php
@@ -34,7 +34,7 @@ class tx_schedulerhttp_eid {
 	function eid_main() {
 		$this->conf = unserialize($GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf'][$this->extKey]);
 		
-		$execCmd = PATH_typo3 . 'cli_dispatch.phpsh scheduler';
+		$execCmd = PATH_typo3 . 'cli_dispatch.phpsh scheduler 2>&1';
 		if (is_array($this->conf) && array_key_exists('debug', $this->conf) && strlen($this->conf['execCmd'])) {
 			$execCmd = str_replace('###CLI_SCRIPT###', $execCmd, $this->conf['execCmd']);
 		}


### PR DESCRIPTION
scheduler_http calls typo3/cli_dispatch.sh, captures its output and
displays that output when debugging is enabled.

It does not catch messages on stderr, thus making it impossible to
find out the reason for errors with the scheduler.

Fixes: #45288
